### PR TITLE
fix: HooksがstdinのJSONと不整合なmatcherにより一度も発火しないバグを修正

### DIFF
--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "/^(Write|Edit|MultiEdit)$/",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -24,7 +24,7 @@
         ]
       },
       {
-        "matcher": "/^(Write|Edit|MultiEdit)$/",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/templates/hooks/auto-format.sh
+++ b/templates/hooks/auto-format.sh
@@ -2,7 +2,9 @@
 # 孔明エージェントチーム — 自動フォーマット
 # PostToolUse(Write|Edit|MultiEdit) で呼ばれ、対象ファイルをフォーマットする
 
-FILE_PATH=$(echo "$CLAUDE_TOOL_INPUT" 2>/dev/null | jq -r '.file_path // empty' 2>/dev/null)
+# Claude Code はフック情報を stdin の JSON で渡す（環境変数ではない）
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
   exit 0

--- a/templates/hooks/log-operation.sh
+++ b/templates/hooks/log-operation.sh
@@ -7,10 +7,14 @@ mkdir -p "$LOG_DIR"
 
 LOG_FILE="$LOG_DIR/$(date '+%Y-%m-%d').jsonl"
 
-TOOL_NAME="${CLAUDE_TOOL_NAME:-unknown}"
 TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
 
+# Claude Code はフック情報を stdin の JSON で渡す（環境変数ではない）
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null)
+TOOL_NAME="${TOOL_NAME:-unknown}"
+
 # ツール入力からファイルパスやコマンドを抽出（軽量に）
-FILE_PATH=$(echo "$CLAUDE_TOOL_INPUT" 2>/dev/null | jq -r '.file_path // .pattern // .command // empty' 2>/dev/null | head -c 200)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.pattern // .tool_input.command // empty' 2>/dev/null | head -c 200)
 
 echo "{\"ts\":\"$TIMESTAMP\",\"tool\":\"$TOOL_NAME\",\"target\":\"$FILE_PATH\"}" >> "$LOG_FILE"

--- a/templates/hooks/notify-phase.sh
+++ b/templates/hooks/notify-phase.sh
@@ -2,7 +2,9 @@
 # 孔明エージェントチーム — フェーズ完了通知
 # PostToolUse(Write) で呼ばれ、成果物ファイルの書き込みを検知して通知
 
-FILE_PATH=$(echo "$CLAUDE_TOOL_INPUT" 2>/dev/null | jq -r '.file_path // empty' 2>/dev/null)
+# Claude Code はフック情報を stdin の JSON で渡す（環境変数ではない）
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 if [ -z "$FILE_PATH" ]; then
   exit 0

--- a/templates/hooks/quality-gate.sh
+++ b/templates/hooks/quality-gate.sh
@@ -6,7 +6,9 @@
 #   - .agents/TEAM.md（チーム設定は手動管理）
 #   - .agents/tachikoma/waves/wave-plan-*.md（計画は /tachikoma-plan 経由で更新）
 
-FILE_PATH=$(echo "$CLAUDE_TOOL_INPUT" 2>/dev/null | jq -r '.file_path // empty' 2>/dev/null)
+# Claude Code はフック情報を stdin の JSON で渡す（環境変数ではない）
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 if [ -z "$FILE_PATH" ]; then
   exit 0


### PR DESCRIPTION
## Summary
- Hooksが2つの独立したバグ（stdin JSON非対応 / matcher記法ミス）により一度も発火していなかった問題を修正
- 4本のhookスクリプトをstdin JSONパースに変更、settings.jsonのmatcherを修正

## Test plan
- [ ] `jq empty templates/.claude/settings.json` で構文確認
- [ ] stdin JSONを模擬してquality-gate.shがTEAM.md書き込みをexit 2でブロックすることを確認
- [ ] stdin JSONを模擬してlog-operation.shがログファイルに記録することを確認
- [ ] 実プロジェクトにsetup.shで展開し、Claude Code上でWrite/Editを実行してhookが実際に発火することを確認